### PR TITLE
new feature: calculate kernel AI

### DIFF
--- a/codegen/grid.py
+++ b/codegen/grid.py
@@ -268,6 +268,7 @@ def shift_index(expr, k, s):
     expr2 = expr.func(*args)
     return expr2
 
+
 def get_ops_expr(expr, arrays):
     """
     - get number of different operations in expression expr
@@ -294,10 +295,11 @@ def get_ops_expr(expr, arrays):
         else:
             add += len(args)-1
         arrays2 = arrays
+        # recursive call of all arguments
         for expr2 in args:
             add2, mul2, arrays2 = get_ops_expr(expr2, arrays2)
-            add += add2
-            mul += mul2
+            add += add2  # accumulate ADD
+            mul += mul2  # acculate MUL
 
         return (add, mul, arrays2)
     # return zero and unchanged array if execution gets here

--- a/codegen/grid.py
+++ b/codegen/grid.py
@@ -268,6 +268,41 @@ def shift_index(expr, k, s):
     expr2 = expr.func(*args)
     return expr2
 
+def get_ops_expr(expr, arrays):
+    """
+    - get number of different operations in expression expr
+    - types of operations are ADD (inc -) and MUL (inc /)
+    - arrays (IndexedBase objects) in expr that are not in list arrays
+    are added to the list
+    - return tuple (#ADD, #MUL, list of unique names of fields)
+    """
+    # add array to list arrays if it is not in it
+    if isinstance(expr, Indexed):
+        base = str(expr.base.label)
+        if base not in arrays:
+            arrays += [base]
+        return (0, 0, arrays)
+
+    mul = 0
+    add = 0
+    if expr.is_Mul or expr.is_Add:
+        args = expr.args
+        # increment MUL or ADD by # arguments less 1
+        # sympy multiplication and addition can have multiple arguments
+        if expr.is_Mul:
+            mul += len(args)-1
+        else:
+            add += len(args)-1
+        arrays2 = arrays
+        for expr2 in args:
+            add2, mul2, arrays2 = get_ops_expr(expr2, arrays2)
+            add += add2
+            mul += mul2
+
+        return (add, mul, arrays2)
+    # return zero and unchanged array if execution gets here
+    return (0, 0, arrays)
+
 
 class Field(IndexedBase):
     """
@@ -952,6 +987,68 @@ class StaggeredGrid:
                                        self.lam[self.index],
                                        Symbol('mu'):
                                        self.mu[0][self.index]})
+
+    def get_velocity_kernel_ai(self):
+        """
+        - get the arithmetic intensity of velocity kernel
+        - get the number of different operations of the velocity field kernel
+        - types of operations are ADD (inc -), MUL (inc /), LOAD, STORE
+        - #LOAD = number of unique fields in the kernel
+        - return tuple (AI, AI_w, #ADD, #MUL, #LOAD, #STORE)
+        - arithmetic intensity AI = (ADD+MUL)/[(LOAD+STORE)*word size]
+        - weighted AI, AI_w = (ADD+MUL)/(2*Max(ADD,MUL)) * AI
+        """
+        store = 0
+        add = 0
+        mul = 0
+        arrays = []  # to store name of arrays loaded
+        for field in self.vfields:
+            store += 1  # increment STORE by 1 (assignment)
+            expr = field.fd_align
+            add2, mul2, arrays2 = get_ops_expr(expr, arrays)
+            add += add2  # accumulate # ADD
+            mul += mul2  # accumulate # MUL
+            arrays = arrays2  # replace with new list of field names
+
+        # 8 byte if double, 4 if float used
+        # media parameter fields are always float, need to amend this
+        word_size = 8 if self.double else 4
+        load = len(arrays)
+        ai = float(add+mul)/(load+store)/word_size
+        ai_w = ai*(add+mul)/max(add, mul)/2.0
+
+        return (ai, ai_w, add, mul, load, store)
+
+    def get_stress_kernel_ai(self):
+        """
+        - get the arithmetic intensity of velocity kernel
+        - get the number of different operations of the stress field kernel
+        - types of operations are ADD (inc -), MUL (inc /), LOAD, STORE
+        - #LOAD = number of unique fields in the kernel
+        - return tuple (#ADD, #MUL, #LOAD, #STORE)
+        - arithmetic intensity AI = (ADD+MUL)/[(LOAD+STORE)*word size]
+        - weighted AI, AI_w = (ADD+MUL)/(2*Max(ADD,MUL)) * AI
+        """
+        store = 0
+        add = 0
+        mul = 0
+        arrays = []  # to store name of arrays loaded
+        for field in self.sfields:
+            store += 1  # increment STORE by 1 (assignment)
+            expr = field.fd_align
+            add2, mul2, arrays2 = get_ops_expr(expr, arrays)
+            add += add2  # accumulate # ADD
+            mul += mul2  # accumulate # MUL
+            arrays = arrays2  # replace with new list of field names
+
+        # 8 byte if double, 4 if float used
+        # media parameter fields are always float, need to amend this
+        word_size = 8 if self.double else 4
+        load = len(arrays)
+        ai = float(add+mul)/(load+store)/word_size
+        ai_w = ai*(add+mul)/max(add, mul)/2.0
+
+        return (ai, ai_w, add, mul, load, store)
 
     # ------------------- sub-routines for output -------------------- #
 

--- a/codegen/grid3d-read.ipynb
+++ b/codegen/grid3d-read.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false
    },
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false
    },
@@ -77,7 +77,7 @@
        "'physical parameters to be read from file, please compile and run the executable'"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 30,
    "metadata": {
     "collapsed": false
    },
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false
    },
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 32,
    "metadata": {
     "collapsed": false
    },
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 33,
    "metadata": {
     "collapsed": false
    },
@@ -198,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 34,
    "metadata": {
     "collapsed": false
    },
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 35,
    "metadata": {
     "collapsed": false
    },
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 36,
    "metadata": {
     "collapsed": false
    },
@@ -267,52 +267,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 37,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
      "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZEAAAAVBAMAAAB1Wc4eAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMmYiu80QdonvRN2Z\nVKvu110NAAAFF0lEQVRYCd1WTYhbVRT+kkzevGSSzGyEWRT7tEgpCBOwCwuFRitCRZ3gYiriz0MU\nHSzMiJS2UDtRlBmxdKZWhRZqAy6KKDSgCxdaI1appQxx525iEaSbtradtLadid8592Um7+Y9KXRl\nL+S+e75zznfPd3/eC3D3tIR3F2i5TzRsBDafekTV7Jj+Edjur6mqFerGAitR54Cdc3pvkSPCqZn3\nGkicPD0zgx3TPwW2ehgzBDw881SQu/rQHLjT76xCwei13WcCMtuV9lcL7fYpV4ETsRinidmqOF/A\nG0Uca1+TcbhtbAX2QIkDduNe6hBXgfBm5C8j2W63l52PsKlobPWkG87XSNWx4AXJKw/NcZ7DzytI\nZ1BHoaFkHaDzTI36q4V2QHkqF8pAfwUFH5k5Ysk5uGU8+1exO1DHr8x3lOwpEWB3HvgTCk81cBM5\n5jQLcyiUoLZ6NgDvo38JgzWbUGPSFTxmO/IeUmUlszzOkxf9lUJDPuXCbiBTRKaGwt/09jWRb6EZ\niguM/kBJ6oESzw+7RWDWh8BfVJ1FuIA7NFiG2zK2ep4GFvzsEUyUbUrNGeldMbglODUls1MwxfUO\nCg35lAvjwJdAumWUDDaRXfpvJW6aStg5V4GpqtYLOV1sxzFRQv8NjsQWjcvAiQbt3tOlMdsky2rZ\nq77rETtu4TSppFOo5ZT50g3sV3hA1nyijuw1nFvPa2+3zp6sEyXSfcI98QIl6bqEl5DhnogosZng\n3KKSSdrP82c3xiwO763aMC5eflewUo9DlLBpoZZT5nPreFThExU+tlSQuI7HsaWqWHcXKHEmKUK7\nWeClSaNk+DuJ5FK6l5Dm20JtJqSuA2tJ+WG9m8mMGeMsejja48m1x4jpvlg+o0QLDXt0vmQZ3yv8\njfRGCe9LLRxKK1Digkq0S0/mV/bEPciICf6243fZE7FXlQAfDBG0mnvQafv41bdgPHjPP1VDZnuM\nEi3Ucsl8+RqOCJwrST9RkdNF64pYoRYo+U2UaIf1b842OgIP+8BOxid3DS9JGm0mONwTPV2ZTwW0\n2mH/JjBStdBkEyOMFjK7qRJTqO3ifIlLRsk+9Q3WkV8q8LDfsEODkp0KlWgnAXwtisCHgFHea7NY\nhVZgi+cWL3sjVUSfyuvm1BxetRGvG+U4w5oYHbXyqsQUGkoy81OJnK58XeaXD16yxWubYxVWM3uS\nv3Dh4mdvSycX+UVz6No+Rj04y5qRbsLYksB6RvzBFvrkyIWaxmyL2BM5o+c6ZKEUvfFBoSGHmS9b\n0xu/BniL3v455Mo5KiqHQsUwSjjIlEy3oZi4YuCPgR+KSNzi4TqEtUUYWxL2gB9xJgwwMtw0ZoH3\nJAyTvghsVTLbo0qCQkM+Mx9v/AF+6b6dma/x88b9GR/iv4sNRTFCTQrTD9xgiTi7nf6rnlFyP/K8\nXHkq6R9zngGMLQkDDecgkh4WJm0+jemrOEftr2Z2DMlJJbNTRMlKod21mflydf0y8k9TDSeB13f9\nwf8xB37hKvvdwcidv3kOA02+lkaXPe3cs0/w1SBw9uypKlfjKBP2y0ht9TjT+4aAryTS4jM5++eH\ner4P954+E5BZKfPHTnppLdRyGK50FQPcz96WjUR7424Xief7PI4iNiXSsYmHux5FlYwC7wCL5/Pi\nWGNTIh3TpNkaRfVyFHgHWCyf48WxxqZEOZwyaTZGUcXyRwXfBhbLl4xNjk2JcvTJbUhFeYj/r9o6\n4F/mRqnPoq5N2gAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\left ( 2.05, \\quad 1.44913793103, \\quad 36, \\quad 87, \\quad 12, \\quad 3\\right )$$"
+      ],
       "text/plain": [
-       "u'#pragma omp for\\nfor(int y=1;y<dim2 - 1;++y){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nU[t1][1][y][z] = (dx1*dx2*lambda[x][y][z]*W[t1][2][y][z] - dx1*dx2*lambda[x][y][z]*W[t1][2][y][z - 1] + dx1*dx3*lambda[x][y][z]*V[t1][2][y][z] - dx1*dx3*lambda[x][y][z]*V[t1][2][y - 1][z] + dx2*dx3*lambda[x][y][z]*U[t1][2][y][z] + 2*dx2*dx3*mu[x][y][z]*U[t1][2][y][z])/(dx2*dx3*(lambda[x][y][z] + 2*mu[x][y][z]));\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int y=1;y<dim2 - 1;++y){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nU[t1][dim1 - 3][y][z] = (-dx1*dx2*lambda[x][y][z]*W[t1][dim1 - 3][y][z] + dx1*dx2*lambda[x][y][z]*W[t1][dim1 - 3][y][z - 1] - dx1*dx3*lambda[x][y][z]*V[t1][dim1 - 3][y][z] + dx1*dx3*lambda[x][y][z]*V[t1][dim1 - 3][y - 1][z] + dx2*dx3*lambda[x][y][z]*U[t1][dim1 - 4][y][z] + 2*dx2*dx3*mu[x][y][z]*U[t1][dim1 - 4][y][z])/(dx2*dx3*(lambda[x][y][z] + 2*mu[x][y][z]));\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int y=1;y<dim2 - 1;++y){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nV[t1][1][y][z] = (-dx1*U[t1][1][y][z] + dx1*U[t1][1][y + 1][z] + dx1*U[t1][2][y][z] - dx1*U[t1][2][y + 1][z] + dx2*(2*V[t1][2][y][z] - V[t1][3][y][z]))/dx2;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int y=1;y<dim2 - 1;++y){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nV[t1][dim1 - 2][y][z] = (-dx1*U[t1][dim1 - 4][y][z] + dx1*U[t1][dim1 - 4][y + 1][z] + dx1*U[t1][dim1 - 3][y][z] - dx1*U[t1][dim1 - 3][y + 1][z] + dx2*(-V[t1][dim1 - 4][y][z] + 2*V[t1][dim1 - 3][y][z]))/dx2;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int y=1;y<dim2 - 1;++y){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nW[t1][1][y][z] = (-dx1*U[t1][1][y][z] + dx1*U[t1][1][y][z + 1] + dx1*U[t1][2][y][z] - dx1*U[t1][2][y][z + 1] + dx3*(2*W[t1][2][y][z] - W[t1][3][y][z]))/dx3;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int y=1;y<dim2 - 1;++y){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nW[t1][dim1 - 2][y][z] = (-dx1*U[t1][dim1 - 4][y][z] + dx1*U[t1][dim1 - 4][y][z + 1] + dx1*U[t1][dim1 - 3][y][z] - dx1*U[t1][dim1 - 3][y][z + 1] + dx3*(-W[t1][dim1 - 4][y][z] + 2*W[t1][dim1 - 3][y][z]))/dx3;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nV[t1][x][1][z] = (dx1*dx2*lambda[x][y][z]*W[t1][x][2][z] - dx1*dx2*lambda[x][y][z]*W[t1][x][2][z - 1] + dx1*dx3*lambda[x][y][z]*V[t1][x][2][z] + 2*dx1*dx3*mu[x][y][z]*V[t1][x][2][z] + dx2*dx3*lambda[x][y][z]*U[t1][x][2][z] - dx2*dx3*lambda[x][y][z]*U[t1][x - 1][2][z])/(dx1*dx3*(lambda[x][y][z] + 2*mu[x][y][z]));\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nV[t1][x][dim2 - 3][z] = (-dx1*dx2*lambda[x][y][z]*W[t1][x][dim2 - 3][z] + dx1*dx2*lambda[x][y][z]*W[t1][x][dim2 - 3][z - 1] + dx1*dx3*lambda[x][y][z]*V[t1][x][dim2 - 4][z] + 2*dx1*dx3*mu[x][y][z]*V[t1][x][dim2 - 4][z] - dx2*dx3*lambda[x][y][z]*U[t1][x][dim2 - 3][z] + dx2*dx3*lambda[x][y][z]*U[t1][x - 1][dim2 - 3][z])/(dx1*dx3*(lambda[x][y][z] + 2*mu[x][y][z]));\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nU[t1][x][1][z] = (dx1*(2*U[t1][x][2][z] - U[t1][x][3][z]) - dx2*V[t1][x][1][z] + dx2*V[t1][x][2][z] + dx2*V[t1][x + 1][1][z] - dx2*V[t1][x + 1][2][z])/dx1;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nU[t1][x][dim2 - 2][z] = (dx1*(-U[t1][x][dim2 - 4][z] + 2*U[t1][x][dim2 - 3][z]) - dx2*V[t1][x][dim2 - 4][z] + dx2*V[t1][x][dim2 - 3][z] + dx2*V[t1][x + 1][dim2 - 4][z] - dx2*V[t1][x + 1][dim2 - 3][z])/dx1;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nW[t1][x][1][z] = (-dx2*V[t1][x][1][z] + dx2*V[t1][x][1][z + 1] + dx2*V[t1][x][2][z] - dx2*V[t1][x][2][z + 1] + dx3*(2*W[t1][x][2][z] - W[t1][x][3][z]))/dx3;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int z=1;z<dim3 - 1;++z){\\r\\nW[t1][x][dim2 - 2][z] = (-dx2*V[t1][x][dim2 - 4][z] + dx2*V[t1][x][dim2 - 4][z + 1] + dx2*V[t1][x][dim2 - 3][z] - dx2*V[t1][x][dim2 - 3][z + 1] + dx3*(-W[t1][x][dim2 - 4][z] + 2*W[t1][x][dim2 - 3][z]))/dx3;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int y=1;y<dim2 - 1;++y){\\r\\nW[t1][x][y][1] = (dx1*dx2*lambda[x][y][z]*W[t1][x][y][2] + 2*dx1*dx2*mu[x][y][z]*W[t1][x][y][2] + dx1*dx3*lambda[x][y][z]*V[t1][x][y][2] - dx1*dx3*lambda[x][y][z]*V[t1][x][y - 1][2] + dx2*dx3*lambda[x][y][z]*U[t1][x][y][2] - dx2*dx3*lambda[x][y][z]*U[t1][x - 1][y][2])/(dx1*dx2*(lambda[x][y][z] + 2*mu[x][y][z]));\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int y=1;y<dim2 - 1;++y){\\r\\nW[t1][x][y][dim3 - 3] = (dx1*dx2*lambda[x][y][z]*W[t1][x][y][dim3 - 4] + 2*dx1*dx2*mu[x][y][z]*W[t1][x][y][dim3 - 4] - dx1*dx3*lambda[x][y][z]*V[t1][x][y][dim3 - 3] + dx1*dx3*lambda[x][y][z]*V[t1][x][y - 1][dim3 - 3] - dx2*dx3*lambda[x][y][z]*U[t1][x][y][dim3 - 3] + dx2*dx3*lambda[x][y][z]*U[t1][x - 1][y][dim3 - 3])/(dx1*dx2*(lambda[x][y][z] + 2*mu[x][y][z]));\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int y=1;y<dim2 - 1;++y){\\r\\nU[t1][x][y][1] = (dx1*(2*U[t1][x][y][2] - U[t1][x][y][3]) - dx3*W[t1][x][y][1] + dx3*W[t1][x][y][2] + dx3*W[t1][x + 1][y][1] - dx3*W[t1][x + 1][y][2])/dx1;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int y=1;y<dim2 - 1;++y){\\r\\nU[t1][x][y][dim3 - 2] = (dx1*(-U[t1][x][y][dim3 - 4] + 2*U[t1][x][y][dim3 - 3]) - dx3*W[t1][x][y][dim3 - 4] + dx3*W[t1][x][y][dim3 - 3] + dx3*W[t1][x + 1][y][dim3 - 4] - dx3*W[t1][x + 1][y][dim3 - 3])/dx1;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int y=1;y<dim2 - 1;++y){\\r\\nV[t1][x][y][1] = (dx2*(2*V[t1][x][y][2] - V[t1][x][y][3]) - dx3*W[t1][x][y][1] + dx3*W[t1][x][y][2] + dx3*W[t1][x][y + 1][1] - dx3*W[t1][x][y + 1][2])/dx2;\\n}\\r\\n}\\r\\n#pragma omp for\\nfor(int x=1;x<dim1 - 1;++x){\\r\\n#pragma ivdep\\nfor(int y=1;y<dim2 - 1;++y){\\r\\nV[t1][x][y][dim3 - 2] = (dx2*(-V[t1][x][y][dim3 - 4] + 2*V[t1][x][y][dim3 - 3]) - dx3*W[t1][x][y][dim3 - 4] + dx3*W[t1][x][y][dim3 - 3] + dx3*W[t1][x][y + 1][dim3 - 4] - dx3*W[t1][x][y + 1][dim3 - 3])/dx2;\\n}\\r\\n}\\r\\n'"
+       "(2.05, 1.44913793103, 36, 87, 12, 3)"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "grid.velocity_bc()"
+    "grid.get_velocity_kernel_ai()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 38,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
      "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAacAAAAVBAMAAAAQtDxhAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMmYiu80QdonvRN2Z\nVKvu110NAAAFUUlEQVRYCd1WXWgcVRT+dnZ39if791gwkNEi1Re7aAQDgY4/FOsPXYukRRQHUWxo\nYQNFU6HYaSlkxRCDrT4UYhdE86DQfajgi3GKVVopSfTJJ7MGpAgxjdFsbdpkPefc/ZmZ7USiPkjv\nw51zzznfd+4392cGuC1byLi9ZN3JcnqBh0pPi7CDI+cRmrpYKmGv1V0Wl7vrv/CwGkatRhoDFYCh\nQHzkGPTh0TJwcOQrGpcO5xRV9PXQtwrb7hWwRdoOkDUA3LFQKtlAyPEEZED1qXWL7em4fiZHrgGE\nHcwZHHwBB/JavV5fx5n6NXZ4ml7FO2X2hHdbkDQBKgBDoT+Hr5ECfoX+LvryeKWcKiiqRL0+5CGj\ngQBbpJ5obw3YThOpAl2mJ8IDrk/tHHeeJvVRAGI2YmvIViiqjSNeSOWBKvZdoYevZSwkxsmnP3XV\ngqQJUCyBImrjMXwPPIjMODIm9iFCHVNFxw752KAomqSe6MvTJIpWOkPeN0xPiAZSnyZ+yh9Q9XEY\nSOSRPI1igTIiVaRrcdpEOZLV2RIVZH4T91ELkiZAsQSK7fwmTgAHkC0gXtN+5+wqdzw9fxNgm9Qd\njpEoGzhGq3K36Q4om+oD9z/bEZD6GAQ+kZBsv2wVyTUaTjZm4gNFay5RKg1q305CQXcx4uxOHEfR\nRGw1wusaLIpik2iTcm6zsSggOUQvOGo2ne2niLI7RUl9RGcxKrnPc190kOSjZALz286zx9+6pBiE\nlNMAAZoN6MqWI2Vk6vcYSNBKLWefGaHbQagydx3J+clobLKvQcpmsylRERpuDRKl5TtFSX3EHTxC\nyNDbDtPtsBH6k16OAezEjjK7fO2sLQ4RxWkKSJZA9RUDE8DMCu3OJUSvFfcgMauoIlZ41cdFQ6ag\npbW59zQl6jidn6EgUa+iQ1SjvlbAF8L2Fr/HhqiieCIVTxk1OKceIkqlMZAsJapu4ZKlnX/xNLAX\nPywXa0i9TwhF9WQnn6JokLrDIkpfItkIEmXfQpTUR7oCmgC1BBcv2rL9XhNPSk65mK0uZSpTRKk0\nBpKloDfoIi7fB+06XfnDW9boStV4fRTVTL7F0zSEoknadPJTRMUKwHdBotK5TlGQ+ggtsahwHhG+\nILIO0vSkN5ehI8HT8bU3G2MRRWkNIFkK+h6JMkhlzywlZmp0sLRlRfUzGt84D6OsUZPUHRFRXSZ0\nO0jUftxClNRnUbT9sjVElomTWLQa9HVauAJSNXcVsdMOHhCDRXGaArKloLtI1Me0aTIGpUWrdPtp\nq4qKys0QyNsYiBapOyaiivSFWVy8+sGQOyI21f9xcfH6FX+A65eRrPBFkTDRxZstNg76AwjdpA1D\n06TF97Vu4JC4WBSnKSBbCjpHZwon6RDltZPoyafpTI0rKgf4zMemKPhnR5G6wyKqh0BSwx0R+6jF\nj1NiuzupD7ooxuhPwsDckL4CWrXBHNI3aV85uDevvshtUPjz0nSF0+RK5zQBCkBBI7Y+gY8sbENs\nQN8DPI7BWUXVD5IpX/g2n6rUInUF1Jmac9iVpe+F//0qUX9AJuPCSX2kHPn4fnr5CWAK2D/8Ewma\noLT+sW9osbw7MEo/YxVOmz4zZag0AQpAoBidziG0MFoGRi9QF79MfEIVvrhg+fmEQpF+aVHNdkv9\ncmMe6JslT3z3uuGbh6qPE/V5+HBSH9EyuvJtMr/1od/xL8eBfMkNJkE1N4froy3kBM/UCA79o0gg\nn7Yx3eZwI0T2aCChHkgWCNkwEMz30n+I0/kE9gYS/s37C8QFBYL5jCCI+DeHi/BWDm/MuGG5/2Nw\nK/AX31K7aHRZtrgAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left ( 3.075, \\quad 2.17370689655, \\quad 72, \\quad 174, \\quad 14, \\quad 6\\right )$$"
+      ],
       "text/plain": [
-       "[[None, None],\n",
-       " ['U[t][1][y][z] = (dx1*dx2*lambda[2][y][z]*W[t][2][y][z] - dx1*dx2*lambda[2][y][z]*W[t][2][y][z - 1] + dx1*dx3*lambda[2][y][z]*V[t][2][y][z] - dx1*dx3*lambda[2][y][z]*V[t][2][y - 1][z] + dx2*dx3*lambda[2][y][z]*U[t][2][y][z] + 2*dx2*dx3*mu[2][y][z]*U[t][2][y][z])/(dx2*dx3*(lambda[2][y][z] + 2*mu[2][y][z]));\\n',\n",
-       "  'U[t][dim1 - 3][y][z] = (-dx1*dx2*lambda[dim1 - 3][y][z]*W[t][dim1 - 3][y][z] + dx1*dx2*lambda[dim1 - 3][y][z]*W[t][dim1 - 3][y][z - 1] - dx1*dx3*lambda[dim1 - 3][y][z]*V[t][dim1 - 3][y][z] + dx1*dx3*lambda[dim1 - 3][y][z]*V[t][dim1 - 3][y - 1][z] + dx2*dx3*lambda[dim1 - 3][y][z]*U[t][dim1 - 4][y][z] + 2*dx2*dx3*mu[dim1 - 3][y][z]*U[t][dim1 - 4][y][z])/(dx2*dx3*(lambda[dim1 - 3][y][z] + 2*mu[dim1 - 3][y][z]));\\n'],\n",
-       " ['U[t][x][1][z] = (dx1*(2*U[t][x][2][z] - U[t][x][3][z]) - dx2*V[t][x][1][z] + dx2*V[t][x][2][z] + dx2*V[t][x + 1][1][z] - dx2*V[t][x + 1][2][z])/dx1;\\n',\n",
-       "  'U[t][x][dim2 - 2][z] = (dx1*(-U[t][x][dim2 - 4][z] + 2*U[t][x][dim2 - 3][z]) - dx2*V[t][x][dim2 - 4][z] + dx2*V[t][x][dim2 - 3][z] + dx2*V[t][x + 1][dim2 - 4][z] - dx2*V[t][x + 1][dim2 - 3][z])/dx1;\\n'],\n",
-       " ['U[t][x][y][1] = (dx1*(2*U[t][x][y][2] - U[t][x][y][3]) - dx3*W[t][x][y][1] + dx3*W[t][x][y][2] + dx3*W[t][x + 1][y][1] - dx3*W[t][x + 1][y][2])/dx1;\\n',\n",
-       "  'U[t][x][y][dim3 - 2] = (dx1*(-U[t][x][y][dim3 - 4] + 2*U[t][x][y][dim3 - 3]) - dx3*W[t][x][y][dim3 - 4] + dx3*W[t][x][y][dim3 - 3] + dx3*W[t][x + 1][y][dim3 - 4] - dx3*W[t][x + 1][y][dim3 - 3])/dx1;\\n']]"
+       "(3.075, 2.17370689655, 72, 174, 14, 6)"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "U.bc"
+    "grid.get_stress_kernel_ai()"
    ]
   },
   {

--- a/codegen/grid3d.ipynb
+++ b/codegen/grid3d.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 69,
    "metadata": {
     "collapsed": false
    },
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 70,
    "metadata": {
     "collapsed": false
    },
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 71,
    "metadata": {
     "collapsed": false
    },
@@ -60,28 +60,28 @@
     "grid.set_stress_fields([Txx,Tyy,Tzz,Txy,Tyz,Txz])\n",
     "grid.set_velocity_fields([U,V,W])\n",
     "grid.set_domain_size((1.0,1.0,1.0))\n",
-    "grid.set_spacing((0.02,0.02,0.02))\n",
+    "grid.set_grid_size((100,100,100))\n",
     "grid.set_time_step(0.005,2.0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 72,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAKAAAAAPBAMAAACRq9klAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEJmJdjLNVN0iZu+7\nq0QgoRR7AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAC5UlEQVQ4Ea2US4gUVxiFv+pyqt/TFRURZtGt\nw2QTRxsdXYihm9EEgkgaA9kFW1QEQW0XbrKZhiwkEGFwIbiyNIMgIt1ZJJJFYhlxIXnYhIhgItOr\nZDm2j9HxMZ1z/5pllqnFOfX/555Tt+69VbB6agJ3GRus3b1ZdRAK/KntwpEK3vj0rO627W5wONzf\nx9uzVTA+3VhRzm26A4nxKOvdUIwNKhRbZO8p0DvBu5IyMWNR9ntY1081uTl8Bil4QNDyvkwUr0et\njxlzXfymTMYG6Yhs0/tpXoFBlV+k7Y35E/6CQxRiDv2hCXwO57kGOxKlGJLvmpFCj/RAJmMDP8Zr\nw8cK7MgK2Ssxi1ALc0uu7DnYBev5FWZCU/Jtis8TY6nH6AuNMDYYfRP6URL4s/PiB7H3Ro1+oetK\nC1y4xU7ewsIpU4KBAhNjucKo1gTjpJh/tVMNN8PFT6b7cDWI+U4zjEpHprRdD+cmoDj8OvKeKLBu\nisZnBpjxYpWRp6qNkyI1PKiGAr3FiBt49SCmBifr5WPkW9ziYh+2LIZZ+Q5UTdH4hSpm/I/Ay5++\nlsMFDkPeC32CmKCerkXlAalv5C20yU2c/DEJNEXNr8CM5erKKzu2ItejI5t75Zfal/5pF8jcB7VW\nSUHL8qaWuE7u9Tua4ULdFPViEmOpQto2xbEV+ZARdVyg1qdzqWqBMB/mm+ReFZv4y+iJB1paw5mW\nHuBO2D5IjBklu2NjbFBW9TAJ1C53/nn0aP6HunrH0S7nlpWaGniPtS+R3rKjLCmkK1xIjKu66PSD\nsUF+Fu4mgTNaQ2n5mGuzI0vuwKa6+kYyTfTZFGb3og/JFPbDRyvGM4w1PJ1OxwajB8nVk8BC1buh\nwFLMh+G6CG4z1spWlMHfIXNkWt63iZL9Yttke8W4Zs99OAvGBp+Nb4bJm2eVsHWyoYN9723kb/xN\nyf5GjT33/gb9L353P4epfQ31pATD4bCNGTXsf73+BUK0DbZhr1zQAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAEIAAAAPBAMAAACivARpAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEJmJdjLNVN0iZu+7\nq0QgoRR7AAABMElEQVQYGYWQsUoDQRRFTzZroms2EWMhWCQWFoLFIpba+QEhfoARA4JsZy3Y2Sgs\nllqksbNJqwSMf7BFbAKBfIKLQTFK4pu3k05wijmcmftm3gws72xghtJK3egmNJfqQzhhNTIJpZUr\nMk/cRTxPR+C1yTYkoLTidvDb+F2Oe1JciMknklBauQ0pNcgmxLJBKab4OaOVIKTSxZ2kiUqVolyG\nMhUvClmUM8b07+UVrYC5d0koU1khJPtGbsQLreFfiUASNDkbS2HhgkpgbzFUyddMwts/MO05X5Sq\n5LVTQ5UyJgF+4kszE+a7eOa1Sp3OB4PvnqzkYmnXSXDbOA1x5Uw6eI8cRo4Uyt4la7XMR0oVif/g\nHmVOWajyIJ9a3n+Fa0sVdqd9treGcLO3Lvn/xi+fU23d6AcdVQAAAABJRU5ErkJggg==\n",
       "text/latex": [
-       "$$0.00816496580928$$"
+       "$$0.00495$$"
       ],
       "text/plain": [
-       "0.00816496580928"
+       "0.00495"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -90,10 +90,7 @@
     "rho, beta, lam, mu = symbols('rho beta lambda mu')\n",
     "t,x,y,z = symbols('t x y z')\n",
     "grid.set_index([x,y,z])\n",
-    "grid.set_variable(rho,1.0, 'float', True)\n",
-    "grid.set_variable(beta,1.0, 'float', True)\n",
-    "grid.set_variable(lam,0.5, 'float', True)\n",
-    "grid.set_variable(mu,0.5, 'float', True)\n",
+    "grid.set_media_params(read=False, rho=1.0, vp=1.0, vs=0.5, rho_file='RHOhomogx200', vp_file='VPhomogx200', vs_file='VShomogx200')\n",
     "grid.get_time_step_limit()"
    ]
   },
@@ -114,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 73,
    "metadata": {
     "collapsed": false
    },
@@ -135,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 74,
    "metadata": {
     "collapsed": false
    },
@@ -154,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 75,
    "metadata": {
     "collapsed": false
    },
@@ -184,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 76,
    "metadata": {
     "collapsed": false
    },
@@ -205,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 77,
    "metadata": {
     "collapsed": false
    },
@@ -216,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 78,
    "metadata": {
     "collapsed": false
    },
@@ -232,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 79,
    "metadata": {
     "collapsed": false
    },
@@ -275,18 +272,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 81,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZsAAAAVBAMAAABie17XAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMmYiu80QdonvRN2Z\nVKvu110NAAAE/0lEQVRYCd1WXWgcVRT+dnZ3dnazu8mL0IdgR4tEQXTRCBYKjhaKCJK1hLQPYgex\n1KCwESmNIDZIICuGJppasKAuiBRR6D70wQdtt1gklNCuPvlk1iCUgiYxPytJTdZzz5nNztzMRvNo\nD+xkzvfd831z7r1zJ8BdFhH7bmnoPtVIL3Dg2tPc0hG3uwQUh7sEkZQZ32WA781T4zQUnAjS7el4\nYpGK0NHiaBWRy9PFIl4f+54wLZ4sPk+I8tTixPB1r04jzOm3cxoEdskqjQGYNUyU1IDPGn8Bx0vp\nvCCcKtwfvXXO0sAfNBUq8ZBLotMU63CEOYDMEoxGo7Fpfoj925+jglmbPf0m6r6CbJXrdGLQjk7p\nGLsgDyRGkHWRnFQDjt4iu6OIOYJwqhW+ckPa+Ql4Apx4SOKs6DTF3nKEPl3FHaRJt5adRNbR5JDY\nQGeZPTUmYyOa5zqNwG3gNx1jFwwDyRySZWT/VANq9DOW6SKISrdFQtoZBV6juVCJII/1S5UnFn3A\nEebLkrkKC7C6OvOwpNgnmjqPQp49faC6tRyYZa7TCKwCE64GsgsGga+AeN3XTkytkyA1rYZTr52L\nh/BuoJ2RfqnyxKy402yUNhvFBRQcJNZZI3iZtdkzCCK14lo2YRc0HOYKcLqko2pLI17FOBMdPG1z\nPVfR+cLYdQURotJt4bWTbTxo+9sxcv1qKOuoy75WO/GKYhwkaXW4M5X64sUtTx8ILCzRfKk6PT6i\n1bF1EMrFquAZJi6OqD+H8FSpcBjJKt0TolIFB8JrBzdXXX87J8DtsA5dzKGtdvZ8q+pppq1FxOmo\n0SLyfgVNzwCVbgxQzisUwDEBHBsKQgC7GHl8x8Qlj46VC3Wkz1HGSKysl3lvCoyrx8772xmRdriK\nLha22oH1AYkU6HcEP4etzntdTc+A2cP3rJWkLgDTlhrKhKyOcsmUQQ8FpB2vJL1M54yx3kTS6lwI\nhrc6j8BYc1tHQaaL22EddfnR1w4+doGTpGKc2rMRFOMsec7zDHBGDY/StKo6PXremFD7RwtyiSxK\nO+8wlaXNvU473KA5JIRTrcZbEICc9lZb7bwKbod16GKObLXzONBH5rL82bquF80htuF5BrgkPR01\nL3UBhpIFV0PEhdpRmy1TAeXqXU3X6ZSh1VEIp1pZsx1zkdq1W+38Mj+/dkt0VGlmfn7h0yGmGy76\nbJibLBSv6XqddcSWxDNIqd0516wLUsBLOiAuqTIfBd3AmzQgTSdTPkPvziQUwqleJx0AU0As12qH\nhp0FV8mF5saR1gm+kkPkb9prU9ib0/VoWMeyeAYp+h7iINcFceChXGRZx8SFjoIzQPSb4o0yfeyi\nFRqKZzFYZYRTgoOh3p1CHl+46PGWynubVkSHS6mk0xH6fmToOMtQO4kB8zDX+gUNG7ND7Kk5pQZg\nDHGdRuCke9xWj+APcUlX+DNK/1GVcZn+hTzzAx1KM78izginV1x/GdK378yho4bI7+MlSRgBRhtz\nXCWlsPo2bWZSM9dKNGOfkMq4upMvXEvz65nnxBOa073T9P3jOo2wVIUmIy7xEjq2rX/LSt2l/oUP\njv4P2eftxrR1CiXCZPbTjq60kxfc2JnePWu3K2nrFEqEyYyR9MF28oK/vDO9a9a025W0dQojwmRM\n9T71tpMX3N6Z3jUbOtWs0tYpjAiToaOW3raw0YT//2If8A9DR7t1hqmsJwAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\left ( 2.5625, \\quad 1.81142241379, \\quad 36, \\quad 87, \\quad 9, \\quad 3\\right )$$"
+      ],
+      "text/plain": [
+       "(2.5625, 1.81142241379, 36, 87, 9, 3)"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grid.get_velocity_kernel_ai()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAAVBAMAAABf6T+xAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMmYiu80QdonvRN2Z\nVKvu110NAAAE3ElEQVRYCd1WXWgcVRT+9ieTzf41L4JgMSM+1ICYRepDUTDYUqyIriKx+NAMQq1B\nMPGhGKHYbahkH0JTaS1YkS6I+OBDA/bVdItVYil18bmYNYhFrE1pfjQ2un7n3J3kzuzsIvZFvbAz\n53zfPd85Z+69Mwv8L0bM/W+3cZ+Uv10uW+UCdHl6sy+Jy7t6xXfenKrAmTtUMJbC91wvl0t40dta\nwYHxS5xUHu+FMpzYC0PbYrQV9EWDHLPHZufKZaLNeixeU1u+mqnJI8hLeUPinlMs8aynd/vyOlK/\ni58FfsGImzhhLIUHGo1GHWcavwJV5GvYX8kWoUxXzfkMhrbFaCvoiwY4yR6n4p9ETT02raltgLbz\nEr4EikB3iV73SaGdpxc9uQfGj8D7AnwLPIKfgB+MpfAXQB7Ye62AnItEEXuRHIQy/cA7MHRADQb0\nRW1Os2cLQN2vx2ZN6gDCjVPCLmAc6GEYHn7B0Ie90DTgA2BRFuwo8BpWgGlPLYVLwBFNitQgnJn4\nkkQr8www7xlaMGuUJMYXtXCazJ4CUszm12PxmtryxRyQ2jECfCr3Uvsmhj3TxNndmHCWmakiFppw\nesw0kV72Um7yuGgpwy1xtgYI3TII+qJB7rAn/if8+fWIb4ZJ7XvN+x69d9UwRSNeaN8E6fMeL/nG\nAy7e40q4ajXhJO8L2y5wtW5NYMtzk3K6GfDKOptgA0K3DAOqaJAzTQxa9Vi8prZ8MVfuPlTh0lXx\nBJ0D6NRE+jcJwDcrHqb5oMfU4lMWeIK/3Xi8gmxjCKPPo4ePn0yCXF/J0ASCQ2JMdBCX7cSSXKse\na4JJbQE8wysuPmTLRXxOvNSxicyghMYvDJ9G11hu2lULENi5KRSSM3jwrrXK6Cqyp+hmBptNNGmd\ns3ExoBHdANXQJkZpbtRj8Zra8mk6DQ9fe8jN4DSQ6+3YxEUNfQjxNQ/b3piuGQsCdxeVyy7F6xg4\ntWUGcXkdX4TDleB2atI6Z+NiQCO6AaqhTRy067F5SW37tG/zbFcQuylNvIpOTXTXNZSPuE9EFj1j\nKSzPM1/kl6SH36k/eoqI32JndWCdb6eaLhbCQ9dA5rQMbeKcXU9wSssHgOdkwJUmuJ2+u3Fj7ZrO\nV5lgJK4iUTAbJ++S2ifbgZbCo3W+o4vIrsomWODbSVZCGJYy4EHolqGgEQ1xkt3he22znuCEfUEX\n2KMrkZ7Rgw2cNHxEE7EqutkETnDrF/oLsSVjGbivqp/yTFG+NjtzPBPHocxbkG+p0C1DQF80SEr2\n2LpizXosXlNbvpjzPBN6sI8pscyjToMyelfMXB4tT/2M0SI+5oHAQW+/ayyFMV8FElX0F9JDiI/h\nSYzUoEym5rzLJKTDegr6olYemtJEzjTRrMfiNTXrsEey5PDtlK2aj93RxgJmgStnZl3zVdicOtxo\n3Eamjtj1qQpSl5/iwxJLYeyoceJjx74C7p27xNfj5e/5DpYAZ/LtXhj6vLcpJpbEGNHVIKHZE6yK\nfw9YTyhOU2dCIVNXmKWrgkxBoqyRDgMW90/M9nofdZSLjIsK2cEdVQ1JxUP+nbrt9dyO0pFxUSGT\nlNkZkno55N+p21bPcTtKR8VFhThFymwPSXWWDk3+G25bvchHvSkYFRcVkpTtn4iavan1r7fuB/4C\n2q+WYJTJDp4AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left ( 4.1, \\quad 2.89827586207, \\quad 72, \\quad 174, \\quad 9, \\quad 6\\right )$$"
+      ],
+      "text/plain": [
+       "(4.1, 2.89827586207, 72, 174, 9, 6)"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grid.get_stress_kernel_ai()"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": []
@@ -308,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION


*** I'm basing this on feature_read_data currently, will probably rebase when the previous pull request merged

*** I did the obvious implementation in counting ADD and MUL etc, I'm not totally sure how the author came up with the numbers in the code in chapter 23 of the pearl book

*** the results are (AI, weighted AI, ADD, MUL, LOAD, STORE)
velocity kernel: (2.5625, 1.81142241379, 36, 87, 9, 3)
stress kernel: (4.1, 2.89827586207, 72, 174, 9,6)
when not reading data from files (lambda, mu, rho are constants and not arrays)

Commit message:

- helper function get_ops_expr() to count number of different operations (ADD, MUL) and different arrays encountered
- grid.get_velocity_kernel_ai() and grid.get_stress_kernel_ai() iterate through fields kernels and calculate arithmetic intensity
- all counting is done in symbolic form, "as it is", i.e. no factorisation of the equation etc
- note that when reading data from file, there are more loads because the parameters are arrays rather than constants
- notebooks updated with these functions
