### PR TITLE
Feature expand kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ FD simulation for 3D elastic wave equation.
 
 running the python script codegen/grid3d.py (this script is the same as the notebook grid3d.ipynb), this will generate test3d.cpp. This can be compiled manually with g++ -fopenmp for instance, or build the make file according to the .travis.yml script.
 
-To enable vtk output, go to grid3d.py and change vtk from False to True in main(), and change output_step to True. Compile with cmake in this case.
+Testing with eigen waves on unit cube is implemented in grid_test.py. Run run_test() with relevant parameters to generate the source code. Some test cases with common settings are defined in grid3d.py, with explanation.
 
-Other grid parameters can be set in the grid3d.py script as well.
-
-The outputs are grid spacing (dx, dy, dz), followed by L2 norms between numerical and analytical solutions for the stress and velocity fields. To switch off this output, change output_convergence from True to False in main().
+The outputs are grid sizes (dimx, dimy, dimz), followed by L2 norms between numerical and analytical solutions for the stress and velocity fields. To switch off this output, change output_convergence from True to False in main().
 
 symbolic subroutines are defined in grid.py

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ running the python script codegen/grid3d.py (this script is the same as the note
 
 Testing with eigen waves on unit cube is implemented in grid_test.py. Run run_test() with relevant parameters to generate the source code. Some test cases with common settings are defined in grid3d.py, with explanation.
 
-The outputs are grid sizes (dimx, dimy, dimz), followed by L2 norms between numerical and analytical solutions for the stress and velocity fields. To switch off this output, change output_convergence from True to False in main().
+The outputs are grid spacings (dx, dy, dz), followed by L2 norms between numerical and analytical solutions for the stress and velocity fields. To switch off this output, change output_convergence from True to False in main().
 
 symbolic subroutines are defined in grid.py

--- a/codegen/grid.py
+++ b/codegen/grid.py
@@ -51,7 +51,7 @@ class MyCPrinter(CCodePrinter):
     def _print_Float(self, expr):
         """
         override method in StrPrinter
-        printing floating point number x in scientific notation if x>100 or x<0.01
+        always printing floating point numbers in scientific notation
         """
         prec = expr._prec
         if prec < 5:
@@ -64,7 +64,7 @@ class MyCPrinter(CCodePrinter):
             strip = True
         elif self._settings["full_prec"] == "auto":
             strip = self._print_level > 1
-        rv = mlib.to_str(expr._mpf_, dps, strip_zeros=strip, max_fixed=2, min_fixed=-2)
+        rv = mlib.to_str(expr._mpf_, dps, strip_zeros=strip, max_fixed=-2, min_fixed=2)
         if rv.startswith('-.0'):
             rv = '-0.' + rv[3:]
         elif rv.startswith('.0'):

--- a/codegen/grid_test.py
+++ b/codegen/grid_test.py
@@ -7,7 +7,7 @@ from grid import *
 
 def run_test(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
              omp=True, simd=False, ivdep=True, io=False, double=False,
-             filename='test.cpp', read=False,
+             filename='test.cpp', read=False, expand=True, eval_const=True,
              rho_file='', vp_file='', vs_file=''):
     """
     create 3D eigen waves and run FD simulation
@@ -30,6 +30,8 @@ def run_test(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
     default False (not include vtk header files)
     :param double: switch for using double as real number variables
     default False (use float)
+    :param expand: expand kernel fully (no factorisation), default True
+    :param eval_const: evaluate all constants in kernel in generated code default True
     :param filename: output source code file name as string
     :param read: switch for reading meida parameters from input files
     default False (not reading)
@@ -39,7 +41,7 @@ def run_test(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
     """
 
     print 'domain size: ' + str(domain_size)
-    print 'gird size: ' + str(grid_size)
+    print 'grid size: ' + str(grid_size)
     print 'dt: ' + str(dt)
     print 'tmax: ' + str(tmax)
 
@@ -71,6 +73,8 @@ def run_test(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
     grid.set_ivdep(ivdep)
     grid.set_io(io)
     grid.set_double(double)
+    grid.set_expand(expand)
+    grid.set_eval_const(eval_const)
 
     grid.set_stress_fields([Txx, Tyy, Tzz, Txy, Tyz, Txz])
     grid.set_velocity_fields([U, V, W])


### PR DESCRIPTION
 new feature: flags for expanding kernel and evaluate constants in kernel

- grid.set_expand() set expand flag, default to True (expanding all factorisation)
- grid.set_eval_const() set eval_const flag, default to True (evaluate all constant by substituting with their values)
- this only applies to main kernel but not BCs. BCs need some re-engineering of code, maybe saving the statement as an equation (rather than C code) in Field objects
- grid_test.py updated
- minor change in README